### PR TITLE
Log Pope Hamster and Poor Hamdes data gap

### DIFF
--- a/data/hamsters/HammJinn.json
+++ b/data/hamsters/HammJinn.json
@@ -1,0 +1,13 @@
+{
+  "ham": "HammJinn",
+  "complete": false,
+  "points": [],
+  "notes": "Unable to confirm any RollerTap upgrade statistics for HammJinn; tracked searches only surfaced unrelated references (no RCC cost/income).",
+  "source": [
+    "https://r.jina.ai/https://duckduckgo.com/?q=%22HammJinn%22",
+    "https://r.jina.ai/https://duckduckgo.com/?q=%22Hamm+Jinn%22"
+  ],
+  "log": [
+    "logs/2025-10-14.md"
+  ]
+}

--- a/data/hamsters/Hamsterita.json
+++ b/data/hamsters/Hamsterita.json
@@ -1,0 +1,13 @@
+{
+  "ham": "Hamsterita",
+  "complete": false,
+  "points": [],
+  "notes": "No public upgrade cost or income data located during 2025-10-14 follow-up sweep; awaiting verifiable figures before populating curve points.",
+  "source": [
+    "https://r.jina.ai/https://tgstat.com/channel/@rollertap?text=Hamsterita",
+    "https://r.jina.ai/https://www.bing.com/search?q=Hamsterita+RollerTap"
+  ],
+  "log": [
+    "logs/2025-10-14.md"
+  ]
+}

--- a/data/hamsters/Magic Hamster.json
+++ b/data/hamsters/Magic Hamster.json
@@ -1,0 +1,30 @@
+{
+  "ham": "Magic Hamster",
+  "complete": false,
+  "points": [
+    {
+      "level": 1,
+      "variants": {
+        "income": [
+          50
+        ]
+      },
+      "notes": "Source reports income only; upgrade cost not disclosed."
+    },
+    {
+      "level": 10,
+      "variants": {
+        "income": [
+          516
+        ]
+      },
+      "notes": "Source reports income only; upgrade cost not disclosed."
+    }
+  ],
+  "source": "https://tgstat.com/channel/@rollertap/146",
+  "log": [
+    "https://duckduckgo.com/html/?q=%5C%22Magic+Hamster%5C%22+%5C%22RCC%5C%22+site%3Atgstat.com",
+    "https://r.jina.ai/https://t.me/RollerTap/146",
+    "logs/2025-10-14.md"
+  ]
+}

--- a/data/hamsters/Mr. Hamster.json
+++ b/data/hamsters/Mr. Hamster.json
@@ -1,0 +1,22 @@
+{
+  "ham": "Mr. Hamster",
+  "complete": false,
+  "points": [
+    {
+      "level": 1,
+      "variants": {
+        "income": [
+          20015
+        ]
+      },
+      "notes": "Income reported as 20.015K RCC/hour; upgrade cost not published."
+    }
+  ],
+  "source": "https://tgstat.com/channel/@rollertap/143",
+  "log": [
+    "https://duckduckgo.com/html/?q=%5C%22Mr.+Hamster%5C%22+%5C%22RCC%5C%22+site%3Atgstat.com",
+    "https://duckduckgo.com/html/?q=%5C%22Mr.+Hamster%5C%22+%5C%22RCC%5C%22+site%3Afacebook.com",
+    "https://r.jina.ai/https://t.me/RollerTap/143",
+    "logs/2025-10-14.md"
+  ]
+}

--- a/data/hamsters/Poor Hamdes.json
+++ b/data/hamsters/Poor Hamdes.json
@@ -1,0 +1,12 @@
+{
+  "ham": "Poor Hamdes",
+  "complete": false,
+  "points": [],
+  "notes": "Searches for RollerTap references only surfaced unrelated poverty articles; no upgrade table or stats found.",
+  "source": [
+    "https://r.jina.ai/https://www.bing.com/search?q=%22Poor+Hamdes%22+RollerTap"
+  ],
+  "log": [
+    "logs/2025-10-14.md"
+  ]
+}

--- a/data/hamsters/Pope Hamster.json
+++ b/data/hamsters/Pope Hamster.json
@@ -1,0 +1,13 @@
+{
+  "ham": "Pope Hamster",
+  "complete": false,
+  "points": [],
+  "notes": "No RollerTap upgrade pricing or income figures published in accessible sources; Telegram mirrors require login for post bodies.",
+  "source": [
+    "https://r.jina.ai/https://www.bing.com/search?q=Pope+Hamster+RollerTap",
+    "https://r.jina.ai/https://tgstat.com/channel/@rollertap?text=Pope%20Hamster"
+  ],
+  "log": [
+    "logs/2025-10-14.md"
+  ]
+}

--- a/data/hamsters/index.json
+++ b/data/hamsters/index.json
@@ -1,0 +1,12 @@
+{
+  "generatedAt": "2025-10-14T23:58:00Z",
+  "totalHamsters": 6,
+  "hamsters": [
+    "Magic Hamster",
+    "Mr. Hamster",
+    "Hamsterita",
+    "HammJinn",
+    "Pope Hamster",
+    "Poor Hamdes"
+  ]
+}

--- a/data/hamsters/logs/2025-10-14.md
+++ b/data/hamsters/logs/2025-10-14.md
@@ -1,0 +1,39 @@
+# 2025-10-14 data-collection session
+
+## Queries attempted
+- https://r.jina.ai/https://duckduckgo.com/?q=%22Magic+Hamster%22+516+RollerTap
+- https://r.jina.ai/https://duckduckgo.com/?q=%22Mr.+Hamster%22+RollerTap+income
+- https://r.jina.ai/https://duckduckgo.com/?q=%22RCC+per+hour%22+RollerTap
+- https://r.jina.ai/https://duckduckgo.com/?q=%22Funny+Hamster%22+RCC+RollerTap
+- https://r.jina.ai/https://medium.com/@5om3/mejor-que-hamster-kombat-rollertap-el-nuevo-tap-game-en-telegram-de-rollercoin-pronto-en-dex-567c643e318a
+
+## Direct sources checked
+- https://r.jina.ai/https://t.me/RollerTap/146 (Magic Hamster income snippet — requires Telegram to view full text)
+- https://r.jina.ai/https://t.me/RollerTap/143 (Mr. Hamster income snippet — requires Telegram to view full text)
+
+## Status
+No new cost data discovered; only existing income snippets remain accessible without Telegram login. Additional sources likely require authenticated access.
+
+## Follow-up sweep (Hamsterita & HammJinn)
+- https://r.jina.ai/https://www.bing.com/search?q=Hamsterita+RollerTap
+- https://r.jina.ai/https://www.bing.com/search?q=%22Hamsterita%22+RollerTap+spreadsheet
+- https://r.jina.ai/https://www.bing.com/search?q=RollerTap+Hamsterita+upgrade
+- https://r.jina.ai/https://tgstat.com/channel/@rollertap?text=Hamsterita
+- https://r.jina.ai/https://tgstat.com/channel/@rollertap/63 (naming contest context)
+- https://r.jina.ai/https://duckduckgo.com/?q=%22Hamm+Jinn%22
+- https://r.jina.ai/https://duckduckgo.com/?q=%22HammJinn%22
+- https://r.jina.ai/https://tgstat.com/channel/@rollertap?page=2 (manual scan for new hamsters)
+- https://r.jina.ai/https://tgstat.com/channel/@rollertap/148 (Mr. Hamster baseline)
+- https://r.jina.ai/https://tgstat.com/channel/@rollertap/147 (boosting tips without numeric data)
+
+No upgrade tables uncovered for Hamsterita or HammJinn; Telegram and search-engine mirrors surface announcements without numeric cost/income figures.
+
+## Follow-up sweep (Pope Hamster & Poor Hamdes)
+- https://r.jina.ai/https://www.bing.com/search?q=%22Pope+Hamster%22+RollerTap
+- https://r.jina.ai/https://www.bing.com/search?q=Pope+Hamster+RollerTap
+- https://r.jina.ai/https://www.bing.com/search?q=%22Pope+Hamster%22+RollerTap+spreadsheet
+- https://r.jina.ai/https://tgstat.com/channel/@rollertap?text=Pope%20Hamster
+- https://r.jina.ai/https://www.reddit.com/r/RollerCoinGame/search/?q=Pope%20Hamster
+- https://r.jina.ai/https://www.bing.com/search?q=%22Poor+Hamdes%22+RollerTap
+
+Search mirrors and community forums mention the character names but provide no numerical upgrade costs or income rates. No JSON-ready datasets located for these hamsters as of this sweep.


### PR DESCRIPTION
## Summary
- add placeholder JSON entries for Pope Hamster and Poor Hamdes referencing the documented search attempts while upgrade stats remain unavailable
- extend the October 14 data-harvest log with the Pope Hamster and Poor Hamdes sweep URLs and findings
- refresh the hamster index metadata to capture the expanded roster and timestamp

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68eed06e6d1c83298b8453357e0aa74b