### PR TITLE
Implement offline-first logger with curve insights

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,12 +6,11 @@ import { NextBestPanel } from './components/NextBestPanel';
 import { buildHamsterFits } from './lib/curves';
 import {
   DEFAULT_OPTIONS,
-  DEFAULT_STATE,
   createLogEntry,
-  loadSnapshot,
+  loadLocalState,
+  persistLastLevels,
   persistLogs,
   persistOptions,
-  persistState,
 } from './lib/storage';
 import { groupByHamster, rollingZScores } from './lib/stats';
 import { HamsterFit, LogEntry, LogEntryV1, OutlierInfo, Options } from './types';
@@ -23,18 +22,18 @@ const signature = (entry: Pick<LogEntryV1, 'ham' | 'lvlTo' | 'cost' | 'dHr'>) =>
 
 export default function App() {
   const [logs, setLogs] = useState<LogEntry[]>([]);
-  const [options, setOptions] = useState<Options>(DEFAULT_OPTIONS);
-  const [prefillLevels, setPrefillLevels] = useState<Record<string, number>>(DEFAULT_STATE.lastHamLevels);
+  const [options, setOptions] = useState<Options>({ ...DEFAULT_OPTIONS });
+  const [prefillLevels, setPrefillLevels] = useState<Record<string, number>>({});
   const [loaded, setLoaded] = useState(false);
   const [importMessage, setImportMessage] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     if (!isBrowser) return;
-    const snapshot = loadSnapshot();
+    const snapshot = loadLocalState();
     setLogs(snapshot.logs);
     setOptions(snapshot.options);
-    setPrefillLevels(snapshot.state.lastHamLevels ?? {});
+    setPrefillLevels(snapshot.lastLevels ?? {});
     setLoaded(true);
   }, []);
 
@@ -50,7 +49,7 @@ export default function App() {
 
   useEffect(() => {
     if (!loaded || !isBrowser) return;
-    persistState({ lastHamLevels: prefillLevels });
+    persistLastLevels(prefillLevels);
   }, [prefillLevels, loaded]);
 
   useEffect(() => {
@@ -125,14 +124,7 @@ export default function App() {
   }, [logs]);
 
   const handleAdd = (entry: LogEntryV1) => {
-    const roi = entry.dHr / entry.cost;
-    const perM = roi * 1_000_000;
-    const normalized: LogEntryV1 = {
-      ...entry,
-      roi,
-      perM,
-    };
-    const log = createLogEntry(normalized);
+    const log = createLogEntry(entry);
     setLogs((prev) => [...prev, log]);
     setPrefillLevels((prev) => ({ ...prev, [entry.ham]: entry.lvlTo }));
   };
@@ -162,19 +154,17 @@ export default function App() {
   };
 
   const handleExportCSV = () => {
-    const rows = logs.map(stripMeta);
     const header = ['ham', 'lvlFrom', 'lvlTo', 'cost', 'dHr', 'totBefore', 'totAfter', 'roi', 'perM', 'excluded'];
     const lines = [header.join(',')];
-    rows.forEach((row) => {
-      lines.push(
-        header
-          .map((key) => {
-            const value = (row as Record<string, unknown>)[key];
-            if (value === undefined) return '';
-            return typeof value === 'number' ? value.toString() : String(value);
-          })
-          .join(',')
-      );
+    logs.forEach((entry) => {
+      const values = header.map((key) => {
+        const raw = (entry as unknown as Record<string, unknown>)[key];
+        if (raw === undefined || raw === null) return '';
+        if (typeof raw === 'number') return raw.toString();
+        if (typeof raw === 'boolean') return raw ? 'true' : 'false';
+        return String(raw);
+      });
+      lines.push(values.join(','));
     });
     const blob = new Blob([lines.join('\n')], { type: 'text/csv' });
     downloadBlob(blob, `rollertap-logs_v1_${timestamp()}.csv`);
@@ -234,6 +224,7 @@ export default function App() {
           lastLevels={prefillLevels}
           options={options}
           duplicates={duplicateSignatures}
+          lastEntry={logs.length ? logs[logs.length - 1] : null}
           onSubmit={handleAdd}
         />
         <div className="grid" style={{ gap: 18 }}>
@@ -334,7 +325,7 @@ export default function App() {
 }
 
 function stripMeta(entry: LogEntry): LogEntryV1 {
-  const { id: _id, createdAt: _createdAt, ...rest } = entry;
+  const { id: _id, createdAt: _createdAt, roi: _roi, perM: _perM, ...rest } = entry;
   return rest;
 }
 
@@ -365,7 +356,6 @@ function normalizeRaw(raw: LogEntryV1): LogEntryV1 | null {
   if (raw.lvlTo !== raw.lvlFrom + 1) return null;
   if (typeof raw.cost !== 'number' || raw.cost <= 0) return null;
   if (typeof raw.dHr !== 'number' || raw.dHr <= 0) return null;
-  const roi = raw.dHr / raw.cost;
   return {
     v: 1,
     ham: raw.ham,
@@ -375,8 +365,6 @@ function normalizeRaw(raw: LogEntryV1): LogEntryV1 | null {
     dHr: raw.dHr,
     totBefore: raw.totBefore,
     totAfter: raw.totAfter,
-    roi,
-    perM: roi * 1_000_000,
     excluded: raw.excluded,
   };
 }

--- a/src/components/EntriesTable.tsx
+++ b/src/components/EntriesTable.tsx
@@ -31,6 +31,11 @@ export function EntriesTable({ logs, outliers, conflicts, onToggleExclude, onDel
     }
   }, [logs, sortKey]);
 
+  const hamsterCount = useMemo(() => {
+    const unique = new Set(logs.map((entry) => entry.ham));
+    return unique.size;
+  }, [logs]);
+
   return (
     <div className="card">
       <header>
@@ -55,63 +60,67 @@ export function EntriesTable({ logs, outliers, conflicts, onToggleExclude, onDel
         {sorted.length === 0 ? (
           <p className="muted">No entries logged yet.</p>
         ) : (
-          <table>
-            <thead>
-              <tr>
-                <th>When</th>
-                <th>Hamster</th>
-                <th>Level</th>
-                <th className="right">Cost</th>
-                <th className="right">Δ/hr</th>
-                <th className="right">ROI</th>
-                <th className="right">Δ/hr per 1M</th>
-                <th>Status</th>
-                <th>Actions</th>
-              </tr>
-            </thead>
-            <tbody>
-              {sorted.map((entry) => {
-                const outlier = outliers.get(entry.id);
-                const conflict = conflicts.has(signature(entry));
-                return (
-                  <tr key={entry.id}>
-                    <td>{new Date(entry.createdAt).toLocaleString()}</td>
-                    <td>{entry.ham}</td>
-                    <td>
-                      {entry.lvlFrom}→<strong>{entry.lvlTo}</strong>
-                    </td>
-                    <td className="right">{formatNumber(entry.cost)}</td>
-                    <td className="right">{formatNumber(entry.dHr)}</td>
-                    <td className="right">{entry.roi !== undefined ? entry.roi.toFixed(6) : '—'}</td>
-                    <td className="right">
-                      {entry.perM !== undefined ? formatShortNumber(entry.perM, 2) : '—'}
-                    </td>
-                    <td>
-                      <div className="flex small">
-                        {entry.excluded && <span className="tag danger">excluded</span>}
-                        {conflict && <span className="tag warn">conflict</span>}
-                        {outlier &&
-                          ((outlier.costZ !== undefined && Math.abs(outlier.costZ) > 2.5) ||
-                            (outlier.gainZ !== undefined && Math.abs(outlier.gainZ) > 2.5)) && (
-                            <span className="tag warn">outlier?</span>
-                          )}
-                      </div>
-                    </td>
-                    <td>
-                      <div className="table-actions">
-                        <button type="button" className="ghost" onClick={() => onToggleExclude(entry.id)}>
-                          {entry.excluded ? 'Include' : 'Exclude'}
-                        </button>
-                        <button type="button" className="danger" onClick={() => onDelete(entry.id)}>
-                          Delete
-                        </button>
-                      </div>
-                    </td>
-                  </tr>
-                );
-              })}
-            </tbody>
-          </table>
+          <>
+            <div className="muted small" style={{ marginBottom: 12 }}>
+              Showing {sorted.length} entries across {hamsterCount} hamsters.
+            </div>
+            <table>
+              <thead>
+                <tr>
+                  <th>When</th>
+                  <th>Hamster</th>
+                  <th>Level</th>
+                  <th className="right">Cost</th>
+                  <th className="right">Δ/hr</th>
+                  <th className="right">ROI</th>
+                  <th className="right">Δ/hr per 1M</th>
+                  <th>Status</th>
+                  <th>Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {sorted.map((entry) => {
+                  const outlier = outliers.get(entry.id);
+                  const conflict = conflicts.has(signature(entry));
+                  const rowClass = entry.excluded ? 'row-dimmed' : undefined;
+                  return (
+                    <tr key={entry.id} className={rowClass}>
+                      <td>{new Date(entry.createdAt).toLocaleString()}</td>
+                      <td>{entry.ham}</td>
+                      <td>
+                        {entry.lvlFrom}→<strong>{entry.lvlTo}</strong>
+                      </td>
+                      <td className="right">{formatNumber(entry.cost)}</td>
+                      <td className="right">{formatNumber(entry.dHr)}</td>
+                      <td className="right">{entry.roi.toFixed(6)}</td>
+                      <td className="right">{formatShortNumber(entry.perM, 2)}</td>
+                      <td>
+                        <div className="flex small">
+                          {entry.excluded && <span className="tag danger">excluded</span>}
+                          {conflict && <span className="tag warn">conflict</span>}
+                          {outlier &&
+                            ((outlier.costZ !== undefined && Math.abs(outlier.costZ) > 2.5) ||
+                              (outlier.gainZ !== undefined && Math.abs(outlier.gainZ) > 2.5)) && (
+                              <span className="tag warn">outlier?</span>
+                            )}
+                        </div>
+                      </td>
+                      <td>
+                        <div className="table-actions">
+                          <button type="button" className="ghost" onClick={() => onToggleExclude(entry.id)}>
+                            {entry.excluded ? 'Include' : 'Exclude'}
+                          </button>
+                          <button type="button" className="danger" onClick={() => onDelete(entry.id)}>
+                            Delete
+                          </button>
+                        </div>
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </>
         )}
       </div>
     </div>

--- a/src/components/HamsterCard.tsx
+++ b/src/components/HamsterCard.tsx
@@ -6,14 +6,31 @@ type HamsterCardProps = {
 };
 
 export function HamsterCard({ fit }: HamsterCardProps) {
-  const { hamster, lastLevel, avgMultiplier, gainAlpha, gainBeta, confidence, levels, costs, gains } = fit;
+  const {
+    hamster,
+    lastLevel,
+    avgMultiplier,
+    costBase,
+    costRatio,
+    gainAlpha,
+    gainBeta,
+    confidence,
+    costFitR2,
+    gainFitR2,
+    levels,
+    costs,
+    gains,
+  } = fit;
   const badgeClass = confidence >= 0.75 ? 'badge good' : confidence >= 0.4 ? 'badge medium' : 'badge low';
+  const confidenceLabel = confidence >= 0.75 ? 'High Confidence' : confidence >= 0.4 ? 'Moderate Confidence' : 'Low Confidence';
 
   return (
     <div className="hamster-card">
       <div className="flex" style={{ justifyContent: 'space-between' }}>
         <h3 style={{ margin: 0 }}>{hamster}</h3>
-        <span className={badgeClass}>confidence {Math.round(confidence * 100)}%</span>
+        <span className={badgeClass}>
+          {confidenceLabel} · {Math.round(confidence * 100)}%
+        </span>
       </div>
       <div className="grid cols-2">
         <div>
@@ -21,8 +38,8 @@ export function HamsterCard({ fit }: HamsterCardProps) {
           <div>{lastLevel ?? '—'}</div>
         </div>
         <div>
-          <span className="muted small">Avg cost ×</span>
-          <div>{avgMultiplier ? avgMultiplier.toFixed(3) : '—'}</div>
+          <span className="muted small">Cost fit r</span>
+          <div>{costRatio ? costRatio.toFixed(3) : avgMultiplier ? avgMultiplier.toFixed(3) : '—'}</div>
         </div>
         <div>
           <span className="muted small">Gain intercept α</span>
@@ -31,6 +48,16 @@ export function HamsterCard({ fit }: HamsterCardProps) {
         <div>
           <span className="muted small">Gain slope β</span>
           <div>{gainBeta !== null ? gainBeta.toFixed(3) : '—'}</div>
+        </div>
+        <div>
+          <span className="muted small">Cost base A</span>
+          <div>{costBase !== null ? formatNumber(costBase, 2) : '—'}</div>
+        </div>
+        <div>
+          <span className="muted small">Fit R² (cost/gain)</span>
+          <div>
+            {costFitR2 !== null ? costFitR2.toFixed(2) : '—'} / {gainFitR2 !== null ? gainFitR2.toFixed(2) : '—'}
+          </div>
         </div>
       </div>
       <div className="muted small">Fits use {levels.length} points</div>

--- a/src/components/LoggerForm.tsx
+++ b/src/components/LoggerForm.tsx
@@ -1,19 +1,27 @@
 import { useEffect, useMemo, useState } from 'react';
 import { parseKMB } from '../lib/parse';
-import { LogEntryV1, Options } from '../types';
+import { LogEntry, LogEntryV1, Options } from '../types';
 
 type LoggerFormProps = {
   knownHamsters: string[];
   lastLevels: Record<string, number>;
   options: Options;
   duplicates: Set<string>;
+  lastEntry: LogEntry | null;
   onSubmit: (entry: LogEntryV1) => void;
 };
 
 const DUPLICATE_SIG = (entry: Pick<LogEntryV1, 'ham' | 'lvlTo' | 'cost' | 'dHr'>) =>
   `${entry.ham}|${entry.lvlTo}|${entry.cost}|${entry.dHr}`;
 
-export function LoggerForm({ knownHamsters, lastLevels, options, duplicates, onSubmit }: LoggerFormProps) {
+export function LoggerForm({
+  knownHamsters,
+  lastLevels,
+  options,
+  duplicates,
+  lastEntry,
+  onSubmit,
+}: LoggerFormProps) {
   const [hamster, setHamster] = useState('');
   const [lvlTo, setLvlTo] = useState<number | ''>('');
   const [lvlFrom, setLvlFrom] = useState<number | ''>('');
@@ -74,7 +82,7 @@ export function LoggerForm({ knownHamsters, lastLevels, options, duplicates, onS
     if (Number.isFinite(dHrValue) && Math.abs(delta - dHrValue) > Math.max(1, dHrValue * 0.02)) {
       setWarning(`Totals mismatch (Δ=${delta.toLocaleString()} vs input ${dHrValue.toLocaleString()})`);
     }
-  }, [totBefore, totAfter, dHrValue]);
+  }, [totBefore, totAfter, dHrValue, options.kmbInput]);
 
   const resetForm = () => {
     setHamster('');
@@ -135,8 +143,6 @@ export function LoggerForm({ knownHamsters, lastLevels, options, duplicates, onS
           ? parseKMB(totAfter)
           : Number(totAfter)
         : undefined,
-      roi: roi ?? undefined,
-      perM: perM ?? undefined,
     };
 
     onSubmit(entry);
@@ -146,6 +152,20 @@ export function LoggerForm({ knownHamsters, lastLevels, options, duplicates, onS
     setDHrRaw('');
     setTotBefore('');
     setTotAfter('');
+    setWarning(null);
+  };
+
+  const handleCloneLast = () => {
+    if (!lastEntry) return;
+    setHamster(lastEntry.ham);
+    const nextLevelFrom = lastEntry.lvlTo;
+    setLvlFrom(nextLevelFrom);
+    setLvlTo(nextLevelFrom + 1);
+    setCostRaw('');
+    setDHrRaw('');
+    setTotBefore('');
+    setTotAfter('');
+    setError(null);
     setWarning(null);
   };
 
@@ -226,11 +246,11 @@ export function LoggerForm({ knownHamsters, lastLevels, options, duplicates, onS
             <div className="kpi-grid">
               <div className="kpi-box">
                 <span className="muted small">ROI (Δ ÷ cost)</span>
-                <strong>{roi ? roi.toFixed(5) : '—'}</strong>
+                <strong>{roi !== null ? roi.toFixed(5) : '—'}</strong>
               </div>
               <div className="kpi-box">
                 <span className="muted small">Δ/hr per 1M</span>
-                <strong>{perM ? perM.toFixed(2) : '—'}</strong>
+                <strong>{perM !== null ? perM.toFixed(2) : '—'}</strong>
               </div>
             </div>
           </div>
@@ -276,6 +296,9 @@ export function LoggerForm({ knownHamsters, lastLevels, options, duplicates, onS
 
         <div className="flex" style={{ marginTop: 16 }}>
           <button type="submit">Add Entry</button>
+          <button type="button" className="ghost" onClick={handleCloneLast} disabled={!lastEntry}>
+            Clone Last
+          </button>
           <button type="button" className="ghost" onClick={resetForm}>
             Clear
           </button>

--- a/src/lib/curves.ts
+++ b/src/lib/curves.ts
@@ -33,6 +33,8 @@ export function buildHamsterFits(entries: LogEntry[]): HamsterFit[] {
       hamster: hamster as HamsterId,
       lastLevel: last?.lvlTo ?? null,
       avgMultiplier,
+      costBase: costFit?.a ?? null,
+      costRatio: costFit?.r ?? null,
       gainAlpha: gainFit?.alpha ?? null,
       gainBeta: gainFit?.beta ?? null,
       confidence,

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,8 +1,8 @@
-import { LogEntry, LogEntryV1, Options, AppState, StorageSnapshot } from '../types';
+import { LogEntry, LogEntryV1, LocalState, Options } from '../types';
 
 const LOG_KEY = 'rt.logs';
-const OPT_KEY = 'rt.opts';
-const STATE_KEY = 'rt.state';
+const LAST_KEY = 'rt.lastLevels';
+const OPT_KEY = 'rt.options';
 
 export const DEFAULT_OPTIONS: Options = {
   kmbInput: true,
@@ -10,55 +10,109 @@ export const DEFAULT_OPTIONS: Options = {
   schemaVer: 1,
 };
 
-export const DEFAULT_STATE: AppState = {
-  lastHamLevels: {},
-};
+const hasWindow = typeof window !== 'undefined';
 
-export function loadSnapshot(): StorageSnapshot {
-  const logsRaw = safeParse<LogEntryV1[]>(localStorage.getItem(LOG_KEY)) ?? [];
-  const options = safeParse<Options>(localStorage.getItem(OPT_KEY)) ?? DEFAULT_OPTIONS;
-  const state = safeParse<AppState>(localStorage.getItem(STATE_KEY)) ?? DEFAULT_STATE;
-  const logs: LogEntry[] = logsRaw.map((entry, index) => ({
-    ...entry,
-    id: `${entry.ham}-${entry.lvlTo}-${entry.cost}-${entry.dHr}-${index}`,
-    createdAt: Date.now() - (logsRaw.length - index) * 1000,
-  }));
-  return { logs, options, state };
-}
+export function loadLocalState(): LocalState {
+  if (!hasWindow) {
+    return {
+      logs: [],
+      lastLevels: {},
+      options: { ...DEFAULT_OPTIONS },
+    };
+  }
 
-export function persistSnapshot(snapshot: StorageSnapshot) {
-  const plainLogs: LogEntryV1[] = snapshot.logs.map(({ id, createdAt, ...rest }) => rest);
-  localStorage.setItem(LOG_KEY, JSON.stringify(plainLogs));
-  localStorage.setItem(OPT_KEY, JSON.stringify(snapshot.options));
-  localStorage.setItem(STATE_KEY, JSON.stringify(snapshot.state));
+  const logsRaw = safeParseArray<LogEntryV1>(localStorage.getItem(LOG_KEY)) ?? [];
+  const lastLevels = safeParse<Record<string, number>>(localStorage.getItem(LAST_KEY)) ?? {};
+  const optionsStored = safeParse<Options>(localStorage.getItem(OPT_KEY));
+  const options = normalizeOptions(optionsStored);
+
+  const now = Date.now();
+  const logs: LogEntry[] = logsRaw.map((entry, index) =>
+    hydrateEntry(entry, now - (logsRaw.length - index - 1) * 1000)
+  );
+
+  return {
+    logs,
+    lastLevels,
+    options,
+  };
 }
 
 export function persistLogs(logs: LogEntry[]) {
-  const plainLogs: LogEntryV1[] = logs.map(({ id, createdAt, ...rest }) => rest);
-  localStorage.setItem(LOG_KEY, JSON.stringify(plainLogs));
+  if (!hasWindow) return;
+  const payload = logs.map(stripMeta);
+  localStorage.setItem(LOG_KEY, JSON.stringify(payload));
 }
 
-export function persistState(state: AppState) {
-  localStorage.setItem(STATE_KEY, JSON.stringify(state));
+export function persistLastLevels(lastLevels: Record<string, number>) {
+  if (!hasWindow) return;
+  localStorage.setItem(LAST_KEY, JSON.stringify(lastLevels));
 }
 
 export function persistOptions(options: Options) {
-  localStorage.setItem(OPT_KEY, JSON.stringify(options));
+  if (!hasWindow) return;
+  localStorage.setItem(OPT_KEY, JSON.stringify({ ...options, schemaVer: 1 }));
+}
+
+export function createLogEntry(entry: LogEntryV1): LogEntry {
+  const createdAt = Date.now();
+  return {
+    ...entry,
+    id: randomId(),
+    createdAt,
+    ...computeMetrics(entry),
+  };
+}
+
+export function hydrateEntry(entry: LogEntryV1, createdAt: number): LogEntry {
+  return {
+    ...entry,
+    id: randomId(),
+    createdAt,
+    ...computeMetrics(entry),
+  };
+}
+
+function computeMetrics(entry: LogEntryV1): Pick<LogEntry, 'roi' | 'perM'> {
+  const roi = entry.cost > 0 ? entry.dHr / entry.cost : 0;
+  const perM = roi * 1_000_000;
+  return {
+    roi,
+    perM,
+  };
+}
+
+function stripMeta(entry: LogEntry): LogEntryV1 {
+  const { id: _id, createdAt: _createdAt, roi: _roi, perM: _perM, ...rest } = entry;
+  return { ...rest };
+}
+
+function normalizeOptions(options: Options | undefined): Options {
+  return {
+    kmbInput: options?.kmbInput ?? DEFAULT_OPTIONS.kmbInput,
+    linearGain: options?.linearGain ?? DEFAULT_OPTIONS.linearGain,
+    schemaVer: 1,
+  };
 }
 
 function safeParse<T>(raw: string | null): T | undefined {
   if (!raw) return undefined;
   try {
     return JSON.parse(raw) as T;
-  } catch {
+  } catch (err) {
+    console.warn('Failed to parse localStorage payload', err);
     return undefined;
   }
 }
 
-export function createLogEntry(data: LogEntryV1): LogEntry {
-  return {
-    ...data,
-    id: crypto.randomUUID(),
-    createdAt: Date.now(),
-  };
+function safeParseArray<T>(raw: string | null): T[] | undefined {
+  const parsed = safeParse<unknown>(raw);
+  return Array.isArray(parsed) ? (parsed as T[]) : undefined;
+}
+
+function randomId(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return Math.random().toString(36).slice(2);
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -213,6 +213,14 @@ tbody tr:hover {
   background: rgba(255, 255, 255, 0.03);
 }
 
+tbody tr.row-dimmed {
+  opacity: 0.55;
+}
+
+tbody tr.row-dimmed:hover {
+  opacity: 0.7;
+}
+
 .table-actions {
   display: flex;
   gap: 8px;

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,17 +9,8 @@ export type LogEntryV1 = {
   dHr: number;
   totBefore?: number;
   totAfter?: number;
-  roi?: number;
-  perM?: number;
   excluded?: boolean;
 };
-
-export type LogEntry = LogEntryV1 & {
-  id: string;
-  createdAt: number;
-};
-
-export type LogsStorage = LogEntryV1[];
 
 export type Options = {
   kmbInput: boolean;
@@ -27,15 +18,18 @@ export type Options = {
   schemaVer: 1;
 };
 
-export type AppState = {
-  lastHamLevels: Record<HamsterId, number>;
+export type LogEntry = LogEntryV1 & {
+  id: string;
+  createdAt: number;
+  roi: number;
+  perM: number;
 };
 
-export type StorageSnapshot = {
+export interface LocalState {
   logs: LogEntry[];
+  lastLevels: Record<HamsterId, number>;
   options: Options;
-  state: AppState;
-};
+}
 
 export type OutlierInfo = {
   costZ?: number;
@@ -46,6 +40,8 @@ export type HamsterFit = {
   hamster: HamsterId;
   lastLevel: number | null;
   avgMultiplier: number | null;
+  costBase: number | null;
+  costRatio: number | null;
   gainAlpha: number | null;
   gainBeta: number | null;
   confidence: number;


### PR DESCRIPTION
## Summary
- persist logger data, last known levels, and options in versioned localStorage keys with derived ROI metrics
- expand logger UI with clone-last workflow, inline KPIs, entry summaries, and improved export/import tooling
- surface richer hamster curve analytics including fitted cost/gain parameters, confidence badges, and dimmed excluded rows

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68efc21515c4832999329f2560915e46